### PR TITLE
make the BND and non-BND write routine the same

### DIFF
--- a/svtools/vcftobedpe.py
+++ b/svtools/vcftobedpe.py
@@ -87,10 +87,10 @@ def writeBND(prim, sec, v, bedpe_out):
         info_B = secondary.get_info_string()    
     bedpe_out.write('\t'.join(map(str,
                                   [chrom_A,
-                                   max(s1,1) - 1,
+                                   max(s1,0) - 1,
                                    max(e1,0),
                                    chrom_B,
-                                   max(s2,1) - 1,
+                                   max(s2,0) - 1,
                                    max(e2,0),
                                    primary.info['EVENT'],
                                    primary.original_qual,


### PR DESCRIPTION
Previously, I had been preventing negative positions, but I've changed it to be consistent with [this](https://github.com/cc2qe/svtools/blob/98582a2bc72fa795eaa256284ef740e1db8d0db2/svtools/vcftobedpe.py#L195)

Looks like with are temporarily(?) going with LOB, which would result in negative positions for telomeric events.