### PR TITLE
switch to using native set class for bron_kerbosh method

### DIFF
--- a/svtools/l_bp.py
+++ b/svtools/l_bp.py
@@ -1,5 +1,3 @@
-import sys
-from sets import Set
 import re
 
 def find_all(a_str, sub):
@@ -425,8 +423,8 @@ def bron_kerbosch(G, R, P, X):
     if (len(P) == 0) and (len(X) == 0):
         yield R
     for v in P:
-        V = Set([v])
-        N = Set([g[0] for g in G[v].edges])
+        V = set([v])
+        N = set([g[0] for g in G[v].edges])
     
         for r in bron_kerbosch(G, \
                                R.union(V), \


### PR DESCRIPTION
This fixes #75. We don't have tests around l_bp for the most part (or lsort or lmerge). The only change here is to use the native set and remove now unused Set import. The method where the set class is used isn't called anywhere, but I don't want to remove it quite yet given that we are still investigating why we need to prune.