### PR TITLE
Negate format fields cache if we're adding the GT field

### DIFF
--- a/svtools/vcf/variant.py
+++ b/svtools/vcf/variant.py
@@ -34,8 +34,11 @@ class Variant(object):
         # make a genotype for each sample at variant
         self.format_string = var_list[8]
         self.format_dict = { key: index for index, key in enumerate(self.format_string.split(':')) }
-        self.format_dict.setdefault('GT', len(self.format_dict)) #add GT if it doesn't exist
         self.gts_string = '\t'.join(var_list[9:])
+
+        if 'GT' not in self.format_dict:
+            self.format_dict['GT'] = len(self.format_dict) #add GT if it doesn't exist
+            self._uncache_gts()
 
         self.info = dict()
         i_split = [a.split('=') for a in var_list[7].split(';')] # temp list of split info column

--- a/tests/vcf_tests/variant_tests.py
+++ b/tests/vcf_tests/variant_tests.py
@@ -67,6 +67,22 @@ class TestVariant(TestCase):
         self.assertEqual(self.variant.get_var_string(use_cached_gt_string=True), self.variant_line)
         self.assertNotEqual(self.variant.get_var_string(), self.variant_line)
 
+    def test_add_genotype(self):
+        header_lines = [
+                '##fileformat=VCFv4.2',
+                '##fileDate=20151202',
+                '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">',
+                '##INFO=<ID=STRANDS,Number=.,Type=String,Description="Strand orientation of the adjacency in BEDPE format (DEL:+-, DUP:-+, INV:++/--)">',
+                '##INFO=<ID=IMAFLAG,Number=.,Type=Flag,Description="Test Flag code">',
+                '##FORMAT=<ID=SU,Number=1,Type=Integer,Description="Number of pieces of evidence supporting the variant">',
+                '##FORMAT=<ID=INACTIVE,Number=1,Type=Integer,Description="A format not in use">',
+                '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878' ]
+        vcf = Vcf()
+        vcf.add_header(header_lines)
+        variant_line = '1	820915	5838_1	N	]GL000232.1:20940]N	0.00	.	SVTYPE=BND;STRANDS=-+:9;IMAFLAG	SU	9'
+        variant = Variant(variant_line.split('\t'), vcf)
+        self.assertEqual(variant.get_gt_string(), './.:9')
+
 if __name__ == "__main__":
     main()
 


### PR DESCRIPTION
This is intended to resolve #130. In cases where the GT field isn't present in the original VCF, svtools VCF classes add it in. If this is the case then we can't utilize cached strings for the samples. Another strategy might be to cease to always add in the GT field, but the ramifications of that are less clear to me at this time.