### PR TITLE
added a header to vcf if no variants found

### DIFF
--- a/svtools/bedpetovcf.py
+++ b/svtools/bedpetovcf.py
@@ -17,7 +17,7 @@ def bedpeToVcf(bedpe_file, vcf_out):
             if line[0:2] == '##':
                 header.append(line)
                 continue
-            elif line[0] == '#' and line[1] != '#':    
+            elif line[0] == '#' and line[1] != '#':
                 sample_list_str = line.rstrip().split('\t', 20)[-1]
                 header.append('\t'.join([
                                     '#CHROM',
@@ -36,15 +36,19 @@ def bedpeToVcf(bedpe_file, vcf_out):
                 myvcf.add_header(header)
                 myvcf.file_format='VCFv4.2'
                 vcf_out.write(myvcf.get_header() + '\n')
-        # 
+        #
         bedpe = Bedpe(line.rstrip().split('\t'))
         variants = converter.convert(bedpe)
         for v in variants:
             vcf_out.write(v.get_var_string() + '\n')
 
-    # close the VCF output file
+    # close the VCF output file and header if no variants found
+    if in_header == True:
+        myvcf.add_header(header)
+        myvcf.file_format='VCFv4.2'
+        vcf_out.write(myvcf.get_header() + '\n')
     vcf_out.close()
-    
+
     return
 
 def description():


### PR DESCRIPTION
I modified bedpetovcf.py to write a header to vcf in the case that no variants are found. Currently an empty file is produced. This is useful when a sample has no variants and you want to produce a valid vcf for merging things later in an automated fashion. Also helps users know that the process didn't die after opening a file handle. 

Tests are passing:
Ran 86 tests in 132.939s

OK

Let me know if I can with help anything.

-Jeff