### PR TITLE
Argcomplete and import performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - deps='libgfortran pip nose coverage statsmodels numpy pandas scipy'
+  - deps='libgfortran pip nose coverage statsmodels numpy pandas scipy argcomplete'
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $deps
   - source activate test-environment
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
 
-    install_requires=['pysam>=0.8.1', 'numpy', 'scipy', 'statsmodels', 'pandas', 'setuptools'],
+    install_requires=['pysam>=0.8.1', 'numpy', 'scipy', 'statsmodels', 'pandas', 'setuptools', 'argcomplete'],
     scripts=['scripts/create_coordinates'],
     
     entry_points={

--- a/svtools/cli.py
+++ b/svtools/cli.py
@@ -1,4 +1,6 @@
-import argparse, sys
+# PYTHON_ARGCOMPLETE_OK
+
+import argcomplete, argparse, sys
 import svtools.lsort
 import svtools.lmerge
 import svtools.vcfpaste
@@ -26,13 +28,13 @@ def svtools_cli_parser():
     parser.add_argument('--version', action='version', version=version_string)
     parser.add_argument('--support', action=SupportAction, nargs=0, help='information on obtaining support')
     subparsers = parser.add_subparsers(title=None, metavar='subcommand', help='description')
-
+    
     lsort = subparsers.add_parser('lsort', help=svtools.lsort.description(), epilog=svtools.lsort.epilog())
     svtools.lsort.add_arguments_to_parser(lsort)
 
     lmerge = subparsers.add_parser('lmerge', help=svtools.lmerge.description(), epilog=svtools.lmerge.epilog())
     svtools.lmerge.add_arguments_to_parser(lmerge)
-    
+
     vcf_paste = subparsers.add_parser('vcfpaste', help=svtools.vcfpaste.description(), epilog=svtools.vcfpaste.epilog())
     svtools.vcfpaste.add_arguments_to_parser(vcf_paste)
 
@@ -65,14 +67,15 @@ def svtools_cli_parser():
 
     varlookup = subparsers.add_parser('varlookup', help=svtools.varlookup.description())
     svtools.varlookup.add_arguments_to_parser(varlookup)
-
+    
     classifier = subparsers.add_parser('classify', help=svtools.sv_classifier.description())
     svtools.sv_classifier.add_arguments_to_parser(classifier)
-
+    
     return parser
 
 def main():
     parser = svtools_cli_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
     sys.exit(args.entry_point(args))
 

--- a/svtools/cli.py
+++ b/svtools/cli.py
@@ -28,7 +28,7 @@ def svtools_cli_parser():
     parser.add_argument('--version', action='version', version=version_string)
     parser.add_argument('--support', action=SupportAction, nargs=0, help='information on obtaining support')
     subparsers = parser.add_subparsers(title=None, metavar='subcommand', help='description')
-    
+
     lsort = subparsers.add_parser('lsort', help=svtools.lsort.description(), epilog=svtools.lsort.epilog())
     svtools.lsort.add_arguments_to_parser(lsort)
 
@@ -43,7 +43,7 @@ def svtools_cli_parser():
 
     genotype = subparsers.add_parser('genotype', help=svtools.genotype.description())
     svtools.genotype.add_arguments_to_parser(genotype)
-    
+
     afreq = subparsers.add_parser('afreq', help=svtools.afreq.description(), epilog=svtools.afreq.epilog())
     svtools.afreq.add_arguments_to_parser(afreq)
 
@@ -61,16 +61,16 @@ def svtools_cli_parser():
 
     bedpesort = subparsers.add_parser('bedpesort', help=svtools.bedpesort.description())
     svtools.bedpesort.add_arguments_to_parser(bedpesort)
-    
+
     prune = subparsers.add_parser('prune', help=svtools.prune.description(), epilog=svtools.prune.epilog())
     svtools.prune.add_arguments_to_parser(prune)
 
     varlookup = subparsers.add_parser('varlookup', help=svtools.varlookup.description())
     svtools.varlookup.add_arguments_to_parser(varlookup)
-    
+
     classifier = subparsers.add_parser('classify', help=svtools.sv_classifier.description())
     svtools.sv_classifier.add_arguments_to_parser(classifier)
-    
+
     return parser
 
 def main():

--- a/svtools/lsort.py
+++ b/svtools/lsort.py
@@ -1,14 +1,14 @@
 import svtools.l_bp as l_bp
-
 import sys
 import os
-import heapq
 import argparse
-from tempfile import gettempdir
 from collections import namedtuple
+import heapq 
+from tempfile import gettempdir
 
 Keyed = namedtuple("Keyed", ["key", "obj"])
-def merge(*iterables):
+
+def merge(*iterables): 
    keyed_iterables = [(Keyed(l_bp.vcf_line_key(obj), obj) for obj in iterable)
                         for iterable in iterables]
    for element in heapq.merge(*keyed_iterables):


### PR DESCRIPTION
added argcomplete for command line autocompletions and made argcomplete a software dependency

changed import of used modules (primarily in classify) to speed up svtools and svtools autocompletes 

if users do not have python autocompletion enabled...they will still get file completions in bash after starting an svtools command

a subsequent pr will need to be made to change installation instructions to enable python autocompletion for those that do not have it on...
