### PR TITLE
set SVLEN even if it is 0

### DIFF
--- a/svtools/lmerge.py
+++ b/svtools/lmerge.py
@@ -484,7 +484,7 @@ def merge(BP, sample_order, v_id, use_product, include_genotypes=False):
         I = ['SVTYPE='   + str(SVTYPE),
              'STRANDS='  + str(STRANDS)
             ]
-        if SVLEN:
+        if SVLEN is not None:
             I += ['SVLEN='    + str(SVLEN)]
         I += ['CIPOS='    + str(CIPOS),
              'CIEND='    + str(CIEND),


### PR DESCRIPTION
When adding in code to ensure that BNDs don't have an SVLEN field, I introduced a bug that also doesn't set SVLEN if it is 0. This is intended to fix that error.