### PR TITLE
Re-raise IOErrors that aren't SIGPIPE

### DIFF
--- a/svtools/cli.py
+++ b/svtools/cli.py
@@ -79,6 +79,8 @@ def main():
     except IOError as e:
         if e.errno == errno.EPIPE:
             sys.exit(141)
+        else:
+            raise
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This resolves #231. We need to explicitly re-raise IOErrors that we trap or we will silently suppress why the program is exiting for non-pipe errors. We will continue to exit for IOErrors with errno.EPIPE with code 141.