### PR TITLE
Set entire sample to missing CN if cnvnator fails

### DIFF
--- a/svtools/copynumber.py
+++ b/svtools/copynumber.py
@@ -1,6 +1,6 @@
 import argparse
 import sys
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import Popen, PIPE
 from svtools.vcf.file import Vcf
 import svtools.utils as su
 

--- a/svtools/copynumber.py
+++ b/svtools/copynumber.py
@@ -86,7 +86,13 @@ def description():
     return 'add copynumber information using cnvnator'
 
 def epilog():
-    return '''As this program runs cnvnator you must provide its location and must remember to have the ROOT package installed and properly configured. The input VCF file may be gzipped. If the input VCF file is omitted then the tool reads from stdin. Note that the coordinates file must end with a line containing the word exit.'''
+    return (
+            'As this program runs cnvnator you must provide its location and '
+            'must remember to have the ROOT package installed and properly '
+            'configured. The input VCF file may be gzipped. If the input VCF '
+            'file is omitted then the tool reads from stdin. Note that the '
+            'coordinates file must end with a line containing the word exit.'
+            )
 
 def add_arguments_to_parser(parser):
     parser.add_argument('-c', '--coordinates', metavar='<FILE>', type=argparse.FileType('r'), required=True, default=None, help='file containing coordinate for which to retrieve copynumber (required)')

--- a/svtools/copynumber.py
+++ b/svtools/copynumber.py
@@ -29,9 +29,6 @@ def update_line_copynumber(v, cn_list, i):
     """
     Updates an individual line's copynumber in place
     """
-    if cn_list[i] == -1:
-        sys.stderr.write('cnvnator produced a copynumber of -1 for variant {0} at coordinate {1}'.format(v[2], str(i + 1)))
-        sys.exit(1)
     if 'CN' not in v[8]:
         v[8] = v[8] + ':CN'
         v[9] = v[9] + ':' + str(cn_list[i])
@@ -48,6 +45,10 @@ def write_copynumber(vcf_file, sample, vcf_out, cn_list):
     vcf = Vcf()
     i = 0
     s_index = -1
+    cn_bad = -1 in cn_list
+    if cn_bad:
+        sys.stderr.write('cnvnator was unable to produce a copynumber value for one or more chromosomes. All copynumber values will be set to missing.')
+        cn_list = [ '.' ] * len(cn_list)
     for line in vcf_file:
         if in_header:
             if line[0] == '#' and line[1] == '#':
@@ -82,10 +83,10 @@ def write_copynumber(vcf_file, sample, vcf_out, cn_list):
     return
 
 def description():
-    return 'add copynumber information using cnvnator-multi'
+    return 'add copynumber information using cnvnator'
 
 def epilog():
-    return '''As this program runs cnvnator-multi you must provide its location and must remember to have the ROOT package installed and properly configured. The input VCF file may be gzipped. If the input VCF file is omitted then the tool reads from stdin. Note that the coordinates file must end with a line containing the word exit.'''
+    return '''As this program runs cnvnator you must provide its location and must remember to have the ROOT package installed and properly configured. The input VCF file may be gzipped. If the input VCF file is omitted then the tool reads from stdin. Note that the coordinates file must end with a line containing the word exit.'''
 
 def add_arguments_to_parser(parser):
     parser.add_argument('-c', '--coordinates', metavar='<FILE>', type=argparse.FileType('r'), required=True, default=None, help='file containing coordinate for which to retrieve copynumber (required)')

--- a/tests/copynumber_tests.py
+++ b/tests/copynumber_tests.py
@@ -8,7 +8,7 @@ import svtools.copynumber
 
 class CopynumberTests(TestCase):
     def test_update_line_copynumber(self):
-        cn_list = [ float('1'), float('-1') ]
+        cn_list = [ float('1') ]
 
         v1 = ['1', '825957', '22', 'N', '<DEL>', '0.00', '.', '.', 'GT', '0/1']
         svtools.copynumber.update_line_copynumber(v1, cn_list, 0)
@@ -19,9 +19,6 @@ class CopynumberTests(TestCase):
         svtools.copynumber.update_line_copynumber(v2, cn_list, 0)
         self.assertEqual(v1[9], '0/1:1.0')
 
-        with self.assertRaises(SystemExit):
-            svtools.copynumber.update_line_copynumber(v1, cn_list, 1)
-
 class IntegrationTest_copynumber(TestCase):
     def run_integration_test(self):
         test_directory = os.path.dirname(os.path.abspath(__file__))
@@ -30,7 +27,28 @@ class IntegrationTest_copynumber(TestCase):
         expected_result = os.path.join(test_data_dir, 'expected.vcf')
         temp_descriptor, temp_output_path = tempfile.mkstemp(suffix='.vcf')
         with open(input, 'r') as input_handle, os.fdopen(temp_descriptor, 'w') as output_handle:
-            svtools.copynumber.write_copynumber(input_handle, 'NA12878', output_handle, ['1.99', '0.13', '5.32', '2.76'])
+            svtools.copynumber.write_copynumber(input_handle, 'NA12878', output_handle, [1.99, 0.13, 5.32, 2.76])
+            expected_lines = open(expected_result).readlines()
+            # set timestamp for diff
+            expected_lines[1] = '##fileDate=' + time.strftime('%Y%m%d') + '\n'
+            #remove reference line
+            produced_lines = open(temp_output_path).readlines()
+            diff = difflib.unified_diff(produced_lines, expected_lines, fromfile=temp_output_path, tofile=expected_result)
+            result = ''.join(diff)
+            if result != '':
+                for line in result:
+                    sys.stdout.write(line)
+                self.assertFalse(result)
+        os.remove(temp_output_path)
+
+    def run_integration_test_w_missing_cn(self):
+        test_directory = os.path.dirname(os.path.abspath(__file__))
+        test_data_dir = os.path.join(test_directory, 'test_data', 'copynumber')
+        input = os.path.join(test_data_dir, 'input.vcf')
+        expected_result = os.path.join(test_data_dir, 'expected_if_missing.vcf')
+        temp_descriptor, temp_output_path = tempfile.mkstemp(suffix='.vcf')
+        with open(input, 'r') as input_handle, os.fdopen(temp_descriptor, 'w') as output_handle:
+            svtools.copynumber.write_copynumber(input_handle, 'NA12878', output_handle, [1.99, 0.13, 5.32, -1])
             expected_lines = open(expected_result).readlines()
             # set timestamp for diff
             expected_lines[1] = '##fileDate=' + time.strftime('%Y%m%d') + '\n'

--- a/tests/test_data/copynumber/expected_if_missing.vcf
+++ b/tests/test_data/copynumber/expected_if_missing.vcf
@@ -1,0 +1,50 @@
+##fileformat=VCFv4.2
+##fileDate=20151202
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=STRANDS,Number=.,Type=String,Description="Strand orientation of the adjacency in BEDPE format (DEL:+-, DUP:-+, INV:++/--)">
+##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">
+##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">
+##INFO=<ID=CIPOS95,Number=2,Type=Integer,Description="Confidence interval (95%) around POS for imprecise variants">
+##INFO=<ID=CIEND95,Number=2,Type=Integer,Description="Confidence interval (95%) around END for imprecise variants">
+##INFO=<ID=MATEID,Number=.,Type=String,Description="ID of mate breakends">
+##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend">
+##INFO=<ID=SECONDARY,Number=0,Type=Flag,Description="Secondary breakend in a multi-line variants">
+##INFO=<ID=SU,Number=.,Type=Integer,Description="Number of pieces of evidence supporting the variant across all samples">
+##INFO=<ID=PE,Number=.,Type=Integer,Description="Number of paired-end reads supporting the variant across all samples">
+##INFO=<ID=SR,Number=.,Type=Integer,Description="Number of split reads supporting the variant across all samples">
+##INFO=<ID=EV,Number=.,Type=String,Description="Type of LUMPY evidence contributing to the variant call">
+##INFO=<ID=PRPOS,Number=.,Type=String,Description="LUMPY probability curve of the POS breakend">
+##INFO=<ID=PREND,Number=.,Type=String,Description="LUMPY probability curve of the END breakend">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=INV,Description="Inversion">
+##ALT=<ID=DUP:TANDEM,Description="Tandem duplication">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=CNV,Description="Copy number variable region">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=SU,Number=1,Type=Integer,Description="Number of pieces of evidence supporting the variant">
+##FORMAT=<ID=PE,Number=1,Type=Integer,Description="Number of paired-end reads supporting the variant">
+##FORMAT=<ID=SR,Number=1,Type=Integer,Description="Number of split reads supporting the variant">
+##FORMAT=<ID=BD,Number=1,Type=Integer,Description="Amount of BED evidence supporting the variant">
+##FORMAT=<ID=GQ,Number=1,Type=Float,Description="Genotype quality">
+##FORMAT=<ID=SQ,Number=1,Type=Float,Description="Phred-scaled probability that this site is variant (non-reference in this sample">
+##FORMAT=<ID=GL,Number=G,Type=Float,Description="Genotype Likelihood, log10-scaled likelihoods of the data given the called genotype for each possible genotype generated from the reference and alternate alleles given the sample ploidy">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##FORMAT=<ID=RO,Number=1,Type=Integer,Description="Reference allele observation count, with partial observations recorded fractionally">
+##FORMAT=<ID=AO,Number=A,Type=Integer,Description="Alternate allele observations, with partial observations recorded fractionally">
+##FORMAT=<ID=QR,Number=1,Type=Integer,Description="Sum of quality of reference observations">
+##FORMAT=<ID=QA,Number=A,Type=Integer,Description="Sum of quality of alternate observations">
+##FORMAT=<ID=RS,Number=1,Type=Integer,Description="Reference allele split-read observation count, with partial observations recorded fractionally">
+##FORMAT=<ID=AS,Number=A,Type=Integer,Description="Alternate allele split-read observation count, with partial observations recorded fractionally">
+##FORMAT=<ID=RP,Number=1,Type=Integer,Description="Reference allele paired-end observation count, with partial observations recorded fractionally">
+##FORMAT=<ID=AP,Number=A,Type=Integer,Description="Alternate allele paired-end observation count, with partial observations recorded fractionally">
+##FORMAT=<ID=AB,Number=A,Type=Float,Description="Allele balance, fraction of observations from alternate allele, QA/(QR+QA)">
+##FORMAT=<ID=CN,Number=1,Type=Float,Description="Copy number of structural variant segment.">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878
+1	825957	22	N	<DEL>	0.00	.	SVTYPE=DEL;SVLEN=-4901217;END=5727174;STRANDS=+-:7;IMPRECISE;CIPOS=-10,344;CIEND=-235,10;CIPOS95=-1,123;CIEND95=-83,2;SU=7;PE=7;SR=0	GT:SU:PE:SR:GQ:SQ:GL:DP:RO:AO:QR:QA:RS:AS:RP:AP:AB:CN	0/0:7:7:0:200:0.00:-11,-66,-279:334:312:22:312:22:0:0:312:22:0.066:.
+1	869423	1	N	<DEL>	789.24	.	SVTYPE=DEL;SVLEN=-846;END=870269;STRANDS=+-:25;IMPRECISE;CIPOS=-10,159;CIEND=-150,10;CIPOS95=-1,34;CIEND95=-40,2;SU=25;PE=25;SR=0	GT:SU:PE:SR:GQ:SQ:GL:DP:RO:AO:QR:QA:RS:AS:RP:AP:AB:CN	1/1:25:25:0:7.18:789.24:-83,-4,-4:67:17:49:17:49:0:0:17:49:0.74:.
+1	1530406	2	N	<DUP>	4.05	.	SVTYPE=DUP;SVLEN=470;END=1530876;STRANDS=-+:7;IMPRECISE;CIPOS=-141,10;CIEND=-10,417;CIPOS95=-64,2;CIEND95=-1,114;SU=7;PE=7;SR=0	GT:SU:PE:SR:GQ:SQ:GL:DP:RO:AO:QR:QA:RS:AS:RP:AP:AB:CN	0/1:7:7:0:4.05:4.05:-13,-13,-37:216:195:21:195:20:0:0:195:20:0.093:.
+1	1531294	3	N	<DUP>	0.00	.	SVTYPE=DUP;SVLEN=344;END=1531638;STRANDS=-+:4;IMPRECISE;CIPOS=-263,10;CIEND=-10,478;CIPOS95=-139,1;CIEND95=-1,175;SU=4;PE=4;SR=0	GT:SU:PE:SR:GQ:SQ:GL:DP:RO:AO:QR:QA:RS:AS:RP:AP:AB:CN	0/0:4:4:0:96.82:0.00:-3,-13,-31:141:133:7:133:7:0:0:133:7:0.05:.


### PR DESCRIPTION
This happens on a chromosome or sample basis.
See https://github.com/abyzovlab/CNVnator/issues/83

Previously we simply died which results in
truncated files and headaches. At this point in time
failing the entire sample seems wise as we think
this an indication that the sample is of poor
quality.

Closes #227